### PR TITLE
DTE-163 parser regression test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,4 +41,5 @@ terraform.rc
 backend-*.conf
 backend.conf
 
-/hello_world
+# Ignore IntelliJ Idea files
+.idea/

--- a/common/codebuild.tf
+++ b/common/codebuild.tf
@@ -476,6 +476,6 @@ resource "aws_codebuild_project" "parser_test" {
 
   secondary_source_version {
     source_identifier = "teDockerBuild"
-    source_version    = "dev"
+    source_version    = "develop"
   }
 }

--- a/common/codebuild.tf
+++ b/common/codebuild.tf
@@ -262,9 +262,35 @@ resource "aws_codebuild_project" "parser_test" {
     image                       = "aws/codebuild/amazonlinux2-x86_64-standard:3.0"
     image_pull_credentials_type = "CODEBUILD"
     privileged_mode             = true
+
     environment_variable {
-      name  = "TESTDATA_BUCKET"
+      name  = "PARSER_TEST_S3_BUCKET"
       value = aws_s3_bucket.dev_tre_test_data.bucket
+    }
+    
+    environment_variable {
+      name  = "PARSER_TEST_S3_PATH_DATA_OK"
+      value = "parser/ok/"
+    }
+    
+    environment_variable {
+      name  = "PARSER_TEST_S3_PATH_DATA_FAIL"
+      value = "parser/fail/"
+    }
+    
+    environment_variable {
+      name  = "PARSER_TEST_S3_PATH_OUTPUT"
+      value = "parser/output-tmp/"
+    }
+    
+    environment_variable {
+      name  = "PARSER_TEST_TESTDATA_SUFFIX"
+      value = ".docx"
+    }
+    
+    environment_variable {
+      name  = "PARSER_TEST_LAMBDA"
+      value = aws_lambda_function.test_judgment_parser.function_name
     }
   }
 
@@ -289,6 +315,6 @@ resource "aws_codebuild_project" "parser_test" {
 
   secondary_source_version {
     source_identifier = "teDockerBuild"
-    source_version    = "DTE167-parser_test"
+    source_version    = "dev"
   }
 }

--- a/common/files/parser-test-buildspec.yaml
+++ b/common/files/parser-test-buildspec.yaml
@@ -6,7 +6,5 @@ phases:
        - aws --version
        - echo TESTING PARSER
        - cd ${CODEBUILD_SRC_DIR_teDockerBuild}
-       - cd parser_testing
-       - python3 test_parser_input.py
-
-
+       - cd testing/parser_testing
+       - python3 test_parser_lambda_fn.py


### PR DESCRIPTION
Updating the `parser_test` `aws_codebuild_project` to invoke the new parser test Python script from https://github.com/nationalarchives/da-transform-judgments-pipeline/tree/develop.