### PR TITLE
DTE-191: Add Step Function version info to metadata (dev)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,4 +41,4 @@ terraform.rc
 backend-*.conf
 backend.conf
 
-/hello_world
+.idea

--- a/deployments/main.tf
+++ b/deployments/main.tf
@@ -9,6 +9,7 @@ module "pipeline_step_function" {
   editorial_retry_trigger_arn = module.tdr_sqs_in_queue.editorial_sqs_queue_arn
   editorial_sns_sub_arn = var.editorial_sns_sub_arn
   account_id = data.aws_caller_identity.aws.account_id
+  tre_version = var.tre_version
   image_versions = var.image_versions
   slack_webhook_url = var.slack_webhook_url
   slack_channel = var.slack_channel
@@ -24,5 +25,4 @@ module "tdr_sqs_in_queue" {
   editorial_role_arn = var.editorial_role_arn
   account_id = data.aws_caller_identity.aws.account_id
   image_versions = var.image_versions
-
 }

--- a/deployments/variables.tf
+++ b/deployments/variables.tf
@@ -49,6 +49,11 @@ variable "editorial_sns_sub_arn" {
   type = string
 }
 
+variable "tre_version" {
+  description = "TRE Step Function version (update if Step Function flow or called Lambda function versions change)"
+  type = string
+}
+
 variable "image_versions" {
   description = "Latest image version for Lambda Functions"
   type = object({


### PR DESCRIPTION
PR to implement changes to inject TRE component versions into the JSON file sent in the editorial payload (`TRE-${CONSIGNMENT_REF}-metadata.json`) in the `dev` environment. Additional groups of PRs will be required to update the other environments.

This PR is one of 3 related PRs in different repositories and must be merged last; i.e. the merge order must be:

1. DTE-191 PR in repo `da-transform-judgments-pipeline`
2. DTE-191 PR in repo `da-transform-terraform-modules`
3. DTE-191 PR in repo `da-transform-terraform-environments` (this one)