### PR TITLE
tre_rapb_in_queue_arn variable added

### DIFF
--- a/deployments/main.tf
+++ b/deployments/main.tf
@@ -44,6 +44,7 @@ module "common" {
   slack_webhook_url = var.slack_webhook_url
   slack_channel = var.slack_channel
   slack_username = var.slack_username
+  tre_rapb_in_queue_arn = module.receive_and_process_bag.tre_rapb_in_queue_arn
 }
 
 # Receive and process bag


### PR DESCRIPTION
This to add a variable to tre-in-topic. The value is the ARN of rapb-in-queue which is outputted from 'receive_and_process_bag' module  and will be used to subscribe to the topic. 