### PR TITLE
TDR-3693:  allow CLI SSO admin to assume terraform role (again)

### DIFF
--- a/common/iam.tf
+++ b/common/iam.tf
@@ -17,8 +17,14 @@ data "aws_iam_policy_document" "terraform-assume-role-policy" {
     }
     principals {
       type        = "AWS"
-      identifiers = ["arn:aws:iam::${data.aws_caller_identity.mgmt.account_id}:role/terraform",
-        "arn:aws:iam::${data.aws_caller_identity.mgmt.account_id}:role/aws-reserved/sso.amazonaws.com/eu-west-2/AWSReservedSSO_AdministratorAccess_bcc0fbcb60597624"]
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.mgmt.account_id}:role/terraform"]
+    }
+  }
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.mgmt.account_id}:role/aws-reserved/sso.amazonaws.com/eu-west-2/AWSReservedSSO_AdministratorAccess_bcc0fbcb60597624"]
     }
   }
 }


### PR DESCRIPTION
Separate out a combo statement so that:
- previous statement as was
- new statement same as we have in V2

Expect merge of this to trigger the `V1 common` aws codepipeline and make the change in management account.