### PR TITLE
TDR-3745: disable v1 parser pipeline

### DIFF
--- a/common/codepipeline_parser_deployments.tf
+++ b/common/codepipeline_parser_deployments.tf
@@ -19,7 +19,6 @@ resource "aws_codepipeline" "parser-deployments" {
 
       configuration = {
         //break the link so V1 pipeline stops being triggered
-        //BranchName           = "main"
         BranchName           = "run-only-on-push-to-non-existent-branch"
         ConnectionArn        = aws_codestarconnections_connection.terraform-codepipeline.arn
         FullRepositoryId     = "nationalarchives/tna-judgments-parser"

--- a/common/codepipeline_parser_deployments.tf
+++ b/common/codepipeline_parser_deployments.tf
@@ -18,7 +18,9 @@ resource "aws_codepipeline" "parser-deployments" {
       output_artifacts = ["source_output"]
 
       configuration = {
-        BranchName           = "main"
+        //break the link so V1 pipeline stops being triggered
+        //BranchName           = "main"
+        BranchName           = "run-only-on-push-to-non-existent-branch"
         ConnectionArn        = aws_codestarconnections_connection.terraform-codepipeline.arn
         FullRepositoryId     = "nationalarchives/tna-judgments-parser"
         OutputArtifactFormat = "CODEBUILD_CLONE_REF"


### PR DESCRIPTION
- Merging to `common` branch (for the platform stack)
- Simple change to disable the parser pipeline in v1 so it stops running on new versions whilst v1 destroy bring planned/done.